### PR TITLE
Fix "infinite connecting" display bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Build directories
+build
+outputs

--- a/PsiphonQt.pro
+++ b/PsiphonQt.pro
@@ -73,15 +73,15 @@ include(./src/QAutostart/QAutostart.pri)
 include(./src/QSingleApp/singleapplication.pri)
 
 CONFIG(debug, debug|release) {
-    DESTDIR = ../../outputs/debug
-    win32:DESTDIR = ../../outputs/debug/win
-    macx:DESTDIR = ../../outputs/debug/mac
-    linux:DESTDIR = ../../outputs/debug/linux
+    DESTDIR = outputs/debug
+    win32:DESTDIR = outputs/debug/win
+    macx:DESTDIR = outputs/debug/mac
+    linux:DESTDIR = outputs/debug/linux
 } else {
-    DESTDIR = ../../outputs/release
-    win32:DESTDIR = ../../outputs/release/win
-    macx:DESTDIR = ../../outputs/release/mac
-    linux:DESTDIR = ../../outputs/release/linux
+    DESTDIR = outputs/release
+    win32:DESTDIR = outputs/release/win
+    macx:DESTDIR = outputs/release/mac
+    linux:DESTDIR = outputs/release/linux
 }
 
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A Psiphon GUI client in Qt, Cute Psiphon for All
   - Manjaro 20.2 Kde 
   
   - Deepin Commiunity 10.03
+  - Debian 11 "bullseye", Gnome 3, Xorg
   
   - Windows 10
   

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # PsiphonQt
 A Psiphon GUI client in Qt, Cute Psiphon for All
 ## MacOS version
+
 ### Monterrey
 <table>
     <td >
@@ -9,6 +10,7 @@ A Psiphon GUI client in Qt, Cute Psiphon for All
 <img height="160"  width="270"  src="https://raw.githubusercontent.com/rsanjuan87/PsiphonQt/main/screencaps/MacOS_Monterrey.jpg"/>
         </td>
     </table>
+    
 ### Catalina
 <table>
     <tr>
@@ -118,24 +120,17 @@ A Psiphon GUI client in Qt, Cute Psiphon for All
   ## Operating systems tested 
   
   - MacOS Monterrey 12.1
-  
   - MacOS BigSur 11
-  
   - MacOS Calalina 10.15.7
   
   - Ubuntu 20.04 Gnome 3 y Kde Plasma
-  
   - Pop_OS 20.10
-  
   - Manjaro 20.2 Kde 
-  
   - Deepin Commiunity 10.03
   - Debian 11 "bullseye", Gnome 3, Xorg
   
   - Windows 10
-  
   - Windows 7
-
  ## Support 
   
   https://t.me/psiphonqt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 
 # PsiphonQt
 A Psiphon GUI client in Qt, Cute Psiphon for All
+
+## Build
+
+Clone this repository, then:
+```sh
+cd PsiphonQt
+mkdir build
+cd build
+qmake .. && make
+# Executable files will be in PsiphonQt/build/outputs directory
+```
+
 ## MacOS version
 
 ### Monterrey

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -324,7 +324,14 @@ void MainWindow::readout(){
             }else{
                 setTunnelConnecting();
             }
-        }else if (type == ("SocksProxyPortInUse")) {
+        } else if (type == "ActiveTunnel") {
+            timerConnecting.stop();
+            if(!wasConnected){
+                wasConnected=true;
+                ui->commandLinkButton->click();
+            }
+            setTunnelConnected();
+        } else if (type == ("SocksProxyPortInUse")) {
             if (CoreControler::coreIsRunning(tunelCorePath)){
                 CoreControler::killCore(tunelCorePath);
                 connect(process, SIGNAL(finished(int)), this, SLOT(startTunnel()));


### PR DESCRIPTION
# Infinite connecting

I am using [psiphon-tunnel-core](https://github.com/Psiphon-Labs/psiphon-tunnel-core-binaries/blob/bfe51e8f86029ff3871d3dc182bb9123053ee3af/linux/psiphon-tunnel-core-x86_64) released on Jan 11, 2022, with custom
tunnel core executable and custom config file (copy-pasted from a Windows PC then edited)
![image](https://user-images.githubusercontent.com/30196401/149371273-207b8e2d-4f17-4f07-bbdc-57d7944b6c9b.png)

PhiphonQt says "Connecting" even after psiphon-tunnel-core actually established a connection. And I see these log on your build:
```
{"data":{"message":"NetworkLatencyMultiplier Min/Max/Lambda: 1.000000/3.000000/2.000000"},"noticeType":"Info","timestamp":"2022-01-13T16:30:47.147Z"}
{"data":{"count":1},"noticeType":"Tunnels","timestamp":"2022-01-13T16:30:47.147Z"}

{"data":{"diagnosticID":"Ezec0ZX2","isTCS":true,"protocol":"FRONTED-MEEK-HTTP-OSSH"},"noticeType":"ActiveTunnel","timestamp":"2022-01-13T16:30:47.152Z"}
```
Note that `setTunnelConnected()` is never triggered here.

# I fixed it, however...
![image](https://user-images.githubusercontent.com/30196401/149372093-994a24a0-ae7e-4701-a699-bdf229ef14dd.png)

```
{"data":{"message":"NetworkLatencyMultiplier Min/Max/Lambda: 1.000000/3.000000/2.000000"},"noticeType":"Info","timestamp":"2022-01-13T16:40:36.948Z"}
{"data":{"count":1},"noticeType":"Tunnels","timestamp":"2022-01-13T16:40:36.948Z"}

Connected
Connected
{"data":{"diagnosticID":"Ezec0ZX2","isTCS":true,"protocol":"FRONTED-MEEK-HTTP-OSSH"},"noticeType":"ActiveTunnel","timestamp":"2022-01-13T16:40:36.960Z"}
```
Note that `setTunnelConnected()` is triggered *twice* .